### PR TITLE
Refactor DB layer, add migrations and scheduler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,9 @@
                  [integrant "0.8.1"]
                  [cheshire "5.13.0"]
                  [clj-time "0.15.2"]
-                 [com.h2database/h2 "2.3.232"]]
+                 [com.h2database/h2 "2.3.232"]
+                 [overtone/at-at "1.2.0"]
+                 [migratus "1.6.3"]]
   :main ^:skip-aot leaderboarder.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/resources/migrations/001-create-users.down.sql
+++ b/resources/migrations/001-create-users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE users;

--- a/resources/migrations/001-create-users.up.sql
+++ b/resources/migrations/001-create-users.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE users (
+  id INTEGER AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR NOT NULL UNIQUE,
+  score INTEGER DEFAULT 0,
+  credits INTEGER DEFAULT 0,
+  geography VARCHAR,
+  sex VARCHAR,
+  age_group VARCHAR,
+  last_active TIMESTAMP
+);

--- a/resources/migrations/002-create-leaderboards.down.sql
+++ b/resources/migrations/002-create-leaderboards.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE leaderboards;

--- a/resources/migrations/002-create-leaderboards.up.sql
+++ b/resources/migrations/002-create-leaderboards.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE leaderboards (
+  id INTEGER AUTO_INCREMENT PRIMARY KEY,
+  creator_id INTEGER REFERENCES users(id),
+  name VARCHAR,
+  filters TEXT,
+  min_users INTEGER DEFAULT 5
+);

--- a/src/leaderboarder/core.clj
+++ b/src/leaderboarder/core.clj
@@ -1,22 +1,3 @@
-;; -*- mode: clojure; -*-
-;;
-;; MVP implementation of a credit‑driven leaderboard API.
-;;
-;; This namespace wires together a simple HTTP service exposing a
-;; handful of endpoints that back a multiplayer social game.  The
-;; server maintains an in‑memory SQL database of users and
-;; leaderboards.  Each user accrues credits over time which can be
-;; spent to increment their own score or decrement another user's
-;; score.  Leaderboards are defined by arbitrary filters (e.g.
-;; geography, age group, time of day) and the creator must sit atop
-;; their board with at least a configurable number of participants.
-;;
-;; The code is structured as a set of Integrant components: a
-;; database connection, a periodic credit incrementer, HTTP route
-;; definitions, a Ring handler with middleware, and a Jetty server.
-;; Integrant cleanly handles component lifecycle (initialization and
-;; teardown) when the application starts or stops.
-
 (ns leaderboarder.core
   (:require
     [integrant.core :as ig]
@@ -25,212 +6,28 @@
     [ring.middleware.defaults :refer [wrap-defaults site-defaults]]
     [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
     [ring.util.response :refer [response]]
-    [clojure.java.jdbc :as jdbc]
-    [honey.sql :as sql]
-    [honey.sql.helpers :as h]
-    [cheshire.core :as cheshire]
-    [ring.adapter.jetty :as jetty])
+    [ring.adapter.jetty :as jetty]
+    [leaderboarder.db :as db]
+    [overtone.at-at :as at])
   (:gen-class))
-
-;; -----------------------------------------------------------------------------
-;; Database initialization
-;;
-;; Create two tables: users and leaderboards.  Users accrue credits and have
-;; optional metadata fields.  Leaderboards store the ID of the creating user,
-;; a name, JSON‑encoded filter specification, and a minimum participant count.
-
-(defn init-db
-  "Initialize the database schema for the game.
-  Returns the db-spec so it can be used downstream as a dependency."
-  [db-spec]
-  ;; Create the users table if it doesn't already exist.  H2 will quietly
-  ;; ignore the create if the table exists, which simplifies repeated
-    ;; development runs.
-  (jdbc/execute! db-spec
-            (sql/format
-              {:create-table [:users :if-not-exists]
-               :with-columns
-                   [[:id :serial :primary-key]
-                    [:username :varchar :not-null :unique]
-                    [:score :integer [:default 0]]
-                    [:credits :integer [:default 0]]
-                    [:geography :varchar]
-                    [:sex :varchar]
-                    [:age_group :varchar]
-                    [:last_active :timestamp]]}))
-  ;; Create the leaderboards table.
-  (jdbc/execute! db-spec
-    (sql/format
-          {:create-table [:leaderboards :if-not-exists]
-           :with-columns
-           [[:id :serial :primary-key]
-            [:creator_id :integer [:references :users :id]]
-            [:name :varchar]
-            [:filters :text]
-            [:min_users :integer [:default 5]]]}))
-  db-spec)
 
 ;; -----------------------------------------------------------------------------
 ;; Periodic credit incrementer
 ;;
-;; Each tick, all users receive one additional credit.  In this simple MVP we
-;; simulate a periodic task with a java.util.Timer.  The interval is
-;; configurable (in milliseconds) via the Integrant config.  Production
-;; deployments should use a more robust scheduler such as Quartz or cron.
+;; Each tick, all users receive one additional credit using a scheduler.
 
 (defn start-credit-incrementer
-  "Return a Timer that increments every user's credits at a fixed interval."
+  "Return a scheduler that increments every user's credits at a fixed interval."
   [db-spec interval-ms]
-  (let [scheduler (java.util.Timer.)]
-    (.schedule scheduler
-      (proxy [java.util.TimerTask] []
-        (run []
-          ;; Use HoneySQL helpers to build the update: set credits = credits + 1
-          (jdbc/execute! db-spec
-            (sql/format
-              (-> (h/update :users)
-                  (h/set {:credits [:+ :credits 1]}))))))
-      0 interval-ms)
-    scheduler))
+  (let [pool (at/mk-pool)
+        task (at/every interval-ms #(db/increment-all-credits db-spec) pool)]
+    {:pool pool :task task}))
 
 (defn stop-credit-incrementer
   "Cancel the periodic credit incrementer."
-  [scheduler]
-  (.cancel scheduler))
-
-;; -----------------------------------------------------------------------------
-;; Database helper functions
-
-(defn get-user
-  "Retrieve a user row by username."
-  [db-spec username]
-  (first
-    (jdbc/query db-spec
-      (sql/format
-        (-> (h/select :*)
-            (h/from :users)
-            (h/where [:= :username username]))))))
-
-(defn use-credit
-  "Spend a credit for a user.  If `action` is :increment-self the user's own
-  score is incremented; otherwise `target-id` is decremented.  No-op if the
-  acting user has no credits."
-  [db-spec user-id action target-id]
-  (jdbc/with-db-transaction [tx db-spec]
-    (let [user (first
-                (jdbc/query tx
-                  (sql/format
-                    (-> (h/select :credits :score)
-                        (h/from :users)
-                        (h/where [:= :id user-id])))))]
-      (when (> (:credits user 0) 0)
-        ;; Deduct one credit from the acting user
-        (jdbc/execute! tx
-          (sql/format
-            (-> (h/update :users)
-                (h/set {:credits [:- :credits 1]})
-                (h/where [:= :id user-id]))))
-        (if (= action :increment-self)
-          ;; Increment the user's own score
-          (jdbc/execute! tx
-            (sql/format
-              (-> (h/update :users)
-                  (h/set {:score [:+ :score 1]})
-                  (h/where [:= :id user-id]))))
-          ;; Otherwise decrement the target's score (if provided)
-          (when target-id
-            (jdbc/execute! tx
-              (sql/format
-                (-> (h/update :users)
-                    (h/set {:score [:- :score 1]})
-                    (h/where [:= :id target-id])))))))))
-
-;; -----------------------------------------------------------------------------
-;; Leaderboard utilities
-
-  (def ^:private EXTRA-LIMIT-BUFFER 10)
-
-  (defn- time-of-day->predicate
-    "Return a HoneySQL predicate for a given time-of-day label, or nil if unsupported.
-     Uses EXTRACT(HOUR FROM last_active), handling wrap-around for night."
-    [value]
-    (let [hour-expr (sql/format [:raw "EXTRACT(HOUR FROM last_active)"])]
-      (case value
-        "morning" [:between hour-expr 6 11]
-        "afternoon" [:between hour-expr 12 17]
-        "evening" [:between hour-expr 18 21]
-        "night" [:or [:between hour-expr 22 23]
-                 [:between hour-expr 0 5]]
-        nil)))
-
-  (defn build-leaderboard-query
-    "Construct a HoneySQL query for a leaderboard given filter criteria.
-    The returned query selects users sorted by descending score. Filters are
-    applied dynamically based on the keys of the `filters` map. Supported
-    filters include :geography, :sex, :age_group, and :time_of_day. The
-    creator's ID is accepted but not currently used here; it's passed for future extension."
-    [_db-spec filters min-users _creator-id]
-    (let [base-query (-> (h/select :*)
-                         (h/from :users)
-                         ;; Sort by descending score, tiebreak by ascending id for stability
-                         (h/order-by [:score :desc] [:id :asc])
-                         ;; Fetch a few extra rows beyond min-users to allow filtering
-                         (h/limit (+ min-users EXTRA-LIMIT-BUFFER)))]
-      (sql/format
-        (reduce-kv
-          (fn [q key value]
-            (case key
-              :geography (h/where q [:= :geography value])
-              :sex (h/where q [:= :sex value])
-              :age_group (h/where q [:= :age_group value])
-              :time_of_day
-              (if-let [pred (time-of-day->predicate value)]
-                (h/where q pred)
-                q)
-              ;; Unknown filter keys are ignored
-              q))
-          base-query
-          filters))))
-(defn create-leaderboard
-  "Create a new leaderboard and return either the full leaderboard or an
-  explanation of why the filters did not produce enough users or why the
-  creator isn't at the top.
-
-  The `filters` map is JSON-encoded for storage.  After inserting the
-  leaderboard row, the query is re-run to validate the constraints."
-  [db-spec creator-id name filters min-users]
-  ;; Persist the filters as JSON
-  (let [filters-json (cheshire/generate-string filters)]
-    (jdbc/insert! db-spec :leaderboards
-      {:creator_id creator-id
-       :name name
-       :filters filters-json
-       :min_users min-users})
-    (let [users (jdbc/query db-spec (build-leaderboard-query db-spec filters min-users creator-id))]
-      (if (and (>= (count users) min-users)
-               ;; Ensure the creator is at the top of the sorted list
-               (= (:id (first users)) creator-id))
-        {:status :created :leaderboard users}
-        {:status :invalid
-         :message "Does not meet criteria"})))))
-
-(defn get-leaderboard
-  "Return the leaderboard row and the associated users by applying the stored
-  filters."
-  [db-spec id]
-  (let [lb (first
-            (jdbc/query db-spec
-              (sql/format
-                (-> (h/select :*)
-                    (h/from :leaderboards)
-                    (h/where [:= :id id])))))]
-    {:leaderboard lb
-     :users (jdbc/query db-spec
-              (build-leaderboard-query
-                db-spec
-                (cheshire/parse-string (:filters lb) true)
-                (:min_users lb)
-                (:creator_id lb)))}))
+  [{:keys [pool task]}]
+  (when task (at/cancel task))
+  (when pool (at/stop pool)))
 
 ;; -----------------------------------------------------------------------------
 ;; HTTP routes and handler
@@ -243,23 +40,22 @@
     (POST "/users" req
       ;; Expect JSON body with :username and optional profile fields
       (let [body (:body req)]
-        (jdbc/insert! db-spec :users
-          (select-keys body [:username :geography :sex :age_group]))
+        (db/create-user db-spec (select-keys body [:username :geography :sex :age_group]))
         (response {:message "User created"})))
     (POST "/credits/use" req
       ;; Spend a credit: body should contain :user_id, :action and optional :target_id
       (let [{:keys [user_id action target_id]} (:body req)
             ;; Convert the action string into a keyword to match our use-credit function
             act (if (keyword? action) action (keyword action))]
-        (use-credit db-spec user_id act target_id)
+        (db/use-credit db-spec user_id act target_id)
         (response {:message "Credit used"})))
     (POST "/leaderboards" req
       ;; Create a new filtered leaderboard
       (let [{:keys [creator_id name filters min_users]} (:body req)]
         (response
-          (create-leaderboard db-spec creator_id name filters min_users))))
+          (db/create-leaderboard db-spec creator_id name filters min_users))))
     (GET "/leaderboards/:id" [id]
-      (response (get-leaderboard db-spec (Integer/parseInt id))))
+      (response (db/get-leaderboard db-spec (Integer/parseInt id))))
     (route/not-found "Not Found")))
 
 (defn make-handler
@@ -275,7 +71,7 @@
 
 ;; DB spec initialization
 (defmethod ig/init-key :db/spec [_ spec]
-  (init-db spec))
+  (db/init-db spec))
 
 ;; Periodic credit incrementer
 (defmethod ig/init-key :credit/incrementer [_ {:keys [db-spec interval-ms]}]
@@ -302,10 +98,6 @@
 ;; -----------------------------------------------------------------------------
 ;; Application configuration
 
-;; A default Integrant configuration defining all components.  In a more
-;; sophisticated application this data could live in an external EDN file
-;; (e.g. resources/system.edn) and be loaded at runtime.
-
 (def config
   {:db/spec {:dbtype "h2:mem" :dbname "leaderboarder-mvp"}
    :credit/incrementer {:db-spec (ig/ref :db/spec)
@@ -317,11 +109,6 @@
 
 ;; -----------------------------------------------------------------------------
 ;; Entry point
-
-;; The -main function is invoked when the application is started from the
-;; command line (via `lein run` or `clojure -M`).  It boots all the
-;; components defined in `config`.  Integrant will also handle halting
-;; components cleanly on JVM shutdown.
 
 (defn -main
   [& _args]

--- a/src/leaderboarder/db.clj
+++ b/src/leaderboarder/db.clj
@@ -1,0 +1,153 @@
+(ns leaderboarder.db
+  (:require [clojure.java.jdbc :as jdbc]
+            [honey.sql :as sql]
+            [honey.sql.helpers :as h]
+            [cheshire.core :as cheshire]
+            [migratus.core :as migratus]))
+
+;; -----------------------------------------------------------------------------
+;; Database initialization via Migratus
+
+(def migration-config
+  {:store :database
+   :migration-dir "migrations"})
+
+(defn init-db
+  "Run database migrations and return the db-spec."
+  [db-spec]
+  (migratus/migrate (assoc migration-config :db db-spec))
+  db-spec)
+
+(defn increment-all-credits
+  "Increment credits for all users."
+  [db-spec]
+  (jdbc/execute! db-spec
+    (sql/format
+      (-> (h/update :users)
+          (h/set {:credits [:+ :credits 1]})))))
+
+(defn create-user
+  "Insert a new user row."
+  [db-spec user]
+  (jdbc/insert! db-spec :users user))
+
+(defn get-user
+  "Retrieve a user row by username."
+  [db-spec username]
+  (first
+    (jdbc/query db-spec
+      (sql/format
+        (-> (h/select :*)
+            (h/from :users)
+            (h/where [:= :username username]))))))
+
+(defn use-credit
+  "Spend a credit for a user. If `action` is :increment-self the user's own
+  score is incremented; otherwise `target-id` is decremented. No-op if the
+  acting user has no credits."
+  [db-spec user-id action target-id]
+  (jdbc/with-db-transaction [tx db-spec]
+    (let [user (first
+                (jdbc/query tx
+                  (sql/format
+                    (-> (h/select :credits :score)
+                        (h/from :users)
+                        (h/where [:= :id user-id])))))]
+      (when (> (:credits user 0) 0)
+        ;; Deduct one credit from the acting user
+        (jdbc/execute! tx
+          (sql/format
+            (-> (h/update :users)
+                (h/set {:credits [:- :credits 1]})
+                (h/where [:= :id user-id]))))
+        (if (= action :increment-self)
+          ;; Increment the user's own score
+          (jdbc/execute! tx
+            (sql/format
+              (-> (h/update :users)
+                  (h/set {:score [:+ :score 1]})
+                  (h/where [:= :id user-id]))))
+          ;; Otherwise decrement the target's score (if provided)
+          (when target-id
+            (jdbc/execute! tx
+              (sql/format
+                (-> (h/update :users)
+                    (h/set {:score [:- :score 1]})
+                    (h/where [:= :id target-id])))))))))
+
+;; -----------------------------------------------------------------------------
+;; Leaderboard utilities
+
+(def ^:private EXTRA-LIMIT-BUFFER 10)
+
+(defn- time-of-day->predicate
+  "Return a HoneySQL predicate for a given time-of-day label, or nil if unsupported.
+   Uses EXTRACT(HOUR FROM last_active), handling wrap-around for night."
+  [value]
+  (let [hour-expr (sql/format [:raw "EXTRACT(HOUR FROM last_active)"])]
+    (case value
+      "morning" [:between hour-expr 6 11]
+      "afternoon" [:between hour-expr 12 17]
+      "evening" [:between hour-expr 18 21]
+      "night" [:or [:between hour-expr 22 23]
+                      [:between hour-expr 0 5]]
+      nil)))
+
+(defn build-leaderboard-query
+  "Construct a HoneySQL query for a leaderboard given filter criteria."
+  [_db-spec filters min-users _creator-id]
+  (let [base-query (-> (h/select :*)
+                       (h/from :users)
+                       ;; Sort by descending score, tiebreak by ascending id for stability
+                       (h/order-by [:score :desc] [:id :asc])
+                       ;; Fetch a few extra rows beyond min-users to allow filtering
+                       (h/limit (+ min-users EXTRA-LIMIT-BUFFER)))]
+    (sql/format
+      (reduce-kv
+        (fn [q key value]
+          (case key
+            :geography (h/where q [:= :geography value])
+            :sex (h/where q [:= :sex value])
+            :age_group (h/where q [:= :age_group value])
+            :time_of_day (if-let [pred (time-of-day->predicate value)]
+                           (h/where q pred)
+                           q)
+            ;; Unknown filter keys are ignored
+            q))
+        base-query
+        filters))))
+
+(defn create-leaderboard
+  "Create a new leaderboard with the given filters and return its status."
+  [db-spec creator-id name filters min-users]
+  (jdbc/with-db-transaction [tx db-spec]
+    (jdbc/insert! tx :leaderboards
+                  {:creator_id creator-id
+                   :name name
+                   :filters (cheshire/generate-string filters)
+                   :min_users min-users})
+    (let [users (jdbc/query tx (build-leaderboard-query tx filters min-users creator-id))]
+      (if (and (>= (count users) min-users)
+               ;; Ensure the creator is at the top of the sorted list
+               (= (:id (first users)) creator-id))
+        {:status :created :leaderboard users}
+        {:status :invalid
+         :message "Does not meet criteria"}))))
+
+(defn get-leaderboard
+  "Return the leaderboard row and the associated users by applying the stored filters."
+  [db-spec id]
+  (let [lb (first
+            (jdbc/query db-spec
+              (sql/format
+                (-> (h/select :*)
+                    (h/from :leaderboards)
+                    (h/where [:= :id id])))))]
+    {:leaderboard lb
+     :users (jdbc/query db-spec
+              (build-leaderboard-query
+                db-spec
+                (cheshire/parse-string (:filters lb) true)
+                (:min_users lb)
+                (:creator_id lb)))}))
+

--- a/test/leaderboarder/core_test.clj
+++ b/test/leaderboarder/core_test.clj
@@ -1,43 +1,42 @@
 (ns leaderboarder.core-test
   (:require [clojure.test :refer [deftest is testing]]
-            [leaderboarder.core :as core]
-            [clojure.java.jdbc :as jdbc]
+            [leaderboarder.db :as db]
             [honey.sql :as sql]))
 
 (deftest get-user-test
   (testing "retrieve user after insert"
     (let [db {:dbtype "h2:mem" :dbname "userdb;DB_CLOSE_DELAY=-1"}
-          db (core/init-db db)]
-      (jdbc/insert! db :users {:username "alice"})
-      (is (= "alice" (:username (core/get-user db "alice")))))))
+          db (db/init-db db)]
+      (db/create-user db {:username "alice"})
+      (is (= "alice" (:username (db/get-user db "alice")))))))
 
 (deftest use-credit-test
-  (testing "credits increment and decrement operations"
-    (let [db {:dbtype "h2:mem" :dbname "creditdb;DB_CLOSE_DELAY=-1"}
-          db (core/init-db db)]
-      (jdbc/insert! db :users {:username "alice" :credits 2 :score 0})
-      (jdbc/insert! db :users {:username "bob" :credits 0 :score 2})
-      (let [alice (core/get-user db "alice")
-            bob (core/get-user db "bob")]
-        ;; increment self
-        (core/use-credit db (:id alice) :increment-self nil)
-        (is (= {:score 1 :credits 1}
-               (select-keys (core/get-user db "alice") [:score :credits])))
-        ;; decrement other
-        (core/use-credit db (:id alice) :attack (:id bob))
-        (is (= 1 (:score (core/get-user db "bob"))))
-        (is (= 0 (:credits (core/get-user db "alice"))))
-        ;; no credits left -> no-op
-        (core/use-credit db (:id alice) :increment-self nil)
-        (is (= {:score 1 :credits 0}
-               (select-keys (core/get-user db "alice") [:score :credits])))))))
+    (testing "credits increment and decrement operations"
+      (let [db {:dbtype "h2:mem" :dbname "creditdb;DB_CLOSE_DELAY=-1"}
+            db (db/init-db db)]
+        (db/create-user db {:username "alice" :credits 2 :score 0})
+        (db/create-user db {:username "bob" :credits 0 :score 2})
+        (let [alice (db/get-user db "alice")
+              bob (db/get-user db "bob")]
+          ;; increment self
+          (db/use-credit db (:id alice) :increment-self nil)
+          (is (= {:score 1 :credits 1}
+                 (select-keys (db/get-user db "alice") [:score :credits])))
+          ;; decrement other
+          (db/use-credit db (:id alice) :attack (:id bob))
+          (is (= 1 (:score (db/get-user db "bob"))))
+          (is (= 0 (:credits (db/get-user db "alice"))))
+          ;; no credits left -> no-op
+          (db/use-credit db (:id alice) :increment-self nil)
+          (is (= {:score 1 :credits 0}
+                 (select-keys (db/get-user db "alice") [:score :credits])))))))
 
 (deftest time-of-day-predicate-test
   (testing "time-of-day filters"
-    (let [hour (sql/format [:raw "EXTRACT(HOUR FROM last_active)"])]
-      (is (= [:between hour 6 11]
-             (#'core/time-of-day->predicate "morning")))
-      (is (= [:or [:between hour 22 23] [:between hour 0 5]]
-             (#'core/time-of-day->predicate "night")))
-      (is (nil? (#'core/time-of-day->predicate "dawn"))))))
+      (let [hour (sql/format [:raw "EXTRACT(HOUR FROM last_active)"])]
+        (is (= [:between hour 6 11]
+               (#'db/time-of-day->predicate "morning")))
+        (is (= [:or [:between hour 22 23] [:between hour 0 5]]
+               (#'db/time-of-day->predicate "night")))
+        (is (nil? (#'db/time-of-day->predicate "dawn"))))))
 


### PR DESCRIPTION
## Summary
- extract persistence logic into dedicated `leaderboarder.db` namespace
- replace `java.util.Timer` with `at-at` scheduler
- manage schema with Migratus SQL migrations

## Testing
- `lein test` *(fails: command not found, unable to install leiningen due to ca-certificates-java error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9428e1408326bb454c365eefccb7