### PR TITLE
Replace at-at with Quartzite scheduler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [cheshire "5.13.0"]
                  [clj-time "0.15.2"]
                  [com.h2database/h2 "2.3.232"]
-                 [overtone/at-at "1.2.0"]
+                 [clojurewerkz/quartzite "2.1.0"]
                  [migratus "1.6.3"]]
   :main ^:skip-aot leaderboarder.core
   :target-path "target/%s"


### PR DESCRIPTION
## Summary
- swap out `overtone/at-at` for Quartzite in `project.clj`
- use Quartzite to schedule periodic credit increments and expose start/stop helpers
- keep Integrant component wired to new scheduler structure

## Testing
- `lein test` *(fails: could not download dependencies from Clojars – 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab96f668a08326a52d1046e107d54e